### PR TITLE
Moves use client down the component tree

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,4 @@
-'use client';
-
-import { LazyMotion, domAnimation } from 'framer-motion';
+import { Metadata } from 'next';
 
 import { DarkModeProvider } from '@/components/StickyHeader/DarkModeToggle/DarkModeProvider';
 import Footer from '@/components/Footer';
@@ -8,6 +6,11 @@ import './globals.css';
 import AppWrapper from '@/components/AppWrapper';
 import StickyHeader from '@/components/StickyHeader';
 import { NavSpyProvider } from '@/components/StickyHeader/HeaderNav/NavSpyProvider';
+
+export const metadata: Metadata = {
+  title: 'A.b. Martinez - Personal Portfolio',
+  description: 'The personal portfolio of A.b. Martinez, Software Engineer.',
+};
 
 export default function RootLayout({
   children,
@@ -18,11 +21,9 @@ export default function RootLayout({
     <DarkModeProvider>
       <NavSpyProvider>
         <AppWrapper>
-          <LazyMotion features={domAnimation}>
-            <StickyHeader />
-            {children}
-            <Footer />
-          </LazyMotion>
+          <StickyHeader />
+          {children}
+          <Footer />
         </AppWrapper>
       </NavSpyProvider>
     </DarkModeProvider>

--- a/src/components/AppWrapper/index.tsx
+++ b/src/components/AppWrapper/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { FC, PropsWithChildren, useEffect, useState } from 'react';
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/react';
@@ -15,11 +17,6 @@ const AppWrapper: FC<PropsWithChildren> = ({ children }) => {
 
   return (
     <html className={darkMode ? 'dark' : ''} lang="en">
-      <title>A.b. Martinez - Personal Portfolio</title>
-      <meta
-        content="The personal portfolio of A.b. Martinez, Software Engineer."
-        name="description"
-      />
       <body
         className={`${
           notoSans.className

--- a/src/components/StickyHeader/DarkModeToggle/index.tsx
+++ b/src/components/StickyHeader/DarkModeToggle/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Sun, Moon } from 'lucide-react';
 
 import { useDarkMode } from './DarkModeProvider';

--- a/src/components/StickyHeader/HeaderNav/index.tsx
+++ b/src/components/StickyHeader/HeaderNav/index.tsx
@@ -1,18 +1,18 @@
-import { Dispatch, FC, SetStateAction, useEffect, useState } from 'react';
+'use client';
+
+import { FC, useEffect, useState } from 'react';
+
+import { useMobileNav } from '../MobileNavToggle/MobileNavProvider';
 
 import { useNavSpy } from './NavSpyProvider';
-import { useNavLinks } from './useNavLinks';
+import { NavLink } from './useNavLinks';
 
-interface HeaderNavProps {
-  mobileNavVisible: boolean;
-  setMobileNavVisible: Dispatch<SetStateAction<boolean>>;
+interface NavProps {
+  navLinks: NavLink[];
 }
 
-const HeaderNav: FC<HeaderNavProps> = ({
-  mobileNavVisible,
-  setMobileNavVisible,
-}) => {
-  const navLinks = useNavLinks();
+const HeaderNav: FC<NavProps> = ({ navLinks }) => {
+  const { mobileNavVisible, toggleMobileNav } = useMobileNav();
   const { activeLink } = useNavSpy();
   const [linkTargets, setLinkTargets] = useState<Record<string, Element>>({});
 
@@ -34,7 +34,7 @@ const HeaderNav: FC<HeaderNavProps> = ({
       behavior: 'smooth',
     });
 
-    setMobileNavVisible(false);
+    toggleMobileNav();
   };
 
   return (

--- a/src/components/StickyHeader/MobileNavToggle/MobileNavProvider.tsx
+++ b/src/components/StickyHeader/MobileNavToggle/MobileNavProvider.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import {
+  FC,
+  PropsWithChildren,
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+
+interface Context {
+  mobileNavVisible: boolean;
+  toggleMobileNav(): void;
+}
+
+const MobileNavContext = createContext<Context | undefined>(undefined);
+
+export const MobileNavProvider: FC<PropsWithChildren> = ({ children }) => {
+  const [mobileNavVisible, setMobileNavVisible] = useState(false);
+
+  const toggleMobileNav = useCallback(() => {
+    setMobileNavVisible((isVisible) => !isVisible);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      mobileNavVisible,
+      toggleMobileNav,
+    }),
+    [mobileNavVisible, toggleMobileNav],
+  );
+
+  return (
+    <MobileNavContext.Provider value={value}>
+      {children}
+    </MobileNavContext.Provider>
+  );
+};
+
+export const useMobileNav = () => {
+  const context = useContext(MobileNavContext);
+
+  if (!context) {
+    throw 'useMobileNav must be called within a MobileNavProvider';
+  }
+
+  return context;
+};

--- a/src/components/StickyHeader/MobileNavToggle/index.tsx
+++ b/src/components/StickyHeader/MobileNavToggle/index.tsx
@@ -1,15 +1,12 @@
+'use client';
+
 import { Menu, X } from 'lucide-react';
-import { Dispatch, FC, SetStateAction } from 'react';
 
-interface MobileNavToggleProps {
-  mobileNavVisible: boolean;
-  setMobileNavVisible: Dispatch<SetStateAction<boolean>>;
-}
+import { useMobileNav } from './MobileNavProvider';
 
-const MobileNavToggle: FC<MobileNavToggleProps> = ({
-  mobileNavVisible,
-  setMobileNavVisible,
-}) => {
+const MobileNavToggle = () => {
+  const { mobileNavVisible, toggleMobileNav } = useMobileNav();
+
   return (
     <button
       className={`${
@@ -17,7 +14,7 @@ const MobileNavToggle: FC<MobileNavToggleProps> = ({
           ? 'text-white-secondary dark:text-black-primary'
           : 'text-black-primary dark:text-white-secondary'
       } z-20 ml-5 md:hidden`}
-      onClick={() => setMobileNavVisible((isVisible) => !isVisible)}
+      onClick={() => toggleMobileNav()}
     >
       {mobileNavVisible ? (
         <X aria-hidden="true" />

--- a/src/components/StickyHeader/index.tsx
+++ b/src/components/StickyHeader/index.tsx
@@ -1,41 +1,35 @@
-'use client';
-
-import { useState } from 'react';
-
 import Heading from '../Heading';
 import ContentContainer from '../ContentContainer';
 
 import HeaderNav from './HeaderNav';
 import HeaderUtils from './HeaderUtils';
 import MobileNavToggle from './MobileNavToggle';
+import { MobileNavProvider } from './MobileNavToggle/MobileNavProvider';
+import { useNavLinks } from './HeaderNav/useNavLinks';
 
 import AbLogo from '@/assets/logos/AbLogo';
 
 const StickyHeader = () => {
-  const [mobileNavVisible, setMobileNavVisible] = useState(false);
+  const navLinks = useNavLinks();
 
   return (
-    <header className="fixed z-20 w-full bg-white-primary/50 py-6 backdrop-blur-md dark:bg-black-primary/50">
-      <ContentContainer className="flex items-center">
-        <div className="flex items-center">
-          <span className="text-black-primary dark:text-white-secondary">
-            <AbLogo />
-          </span>
-          <Heading className="ml-3 hidden font-normal lg:block" level="h5">
-            A.b. Martinez
-          </Heading>
-        </div>
-        <HeaderNav
-          mobileNavVisible={mobileNavVisible}
-          setMobileNavVisible={setMobileNavVisible}
-        />
-        <HeaderUtils />
-        <MobileNavToggle
-          mobileNavVisible={mobileNavVisible}
-          setMobileNavVisible={setMobileNavVisible}
-        />
-      </ContentContainer>
-    </header>
+    <MobileNavProvider>
+      <header className="fixed z-20 w-full bg-white-primary/50 py-6 backdrop-blur-md dark:bg-black-primary/50">
+        <ContentContainer className="flex items-center">
+          <div className="flex items-center">
+            <span className="text-black-primary dark:text-white-secondary">
+              <AbLogo />
+            </span>
+            <Heading className="ml-3 hidden font-normal lg:block" level="h5">
+              A.b. Martinez
+            </Heading>
+          </div>
+          <HeaderNav navLinks={navLinks} />
+          <HeaderUtils />
+          <MobileNavToggle />
+        </ContentContainer>
+      </header>
+    </MobileNavProvider>
   );
 };
 


### PR DESCRIPTION
This PR moves the `'use client'` declarations further down the component tree to take advantage of server components higher up where possible. 